### PR TITLE
plot_factors: fix continuous color scale when plotting >2 factors

### DIFF
--- a/R/plot_factors.R
+++ b/R/plot_factors.R
@@ -420,20 +420,28 @@ plot_factors <- function(object, factors = c(1, 2), groups = "all",
       legend.text = element_text(size=rel(1.2)),
       legend.title = element_text(size=rel(1.2))
     )
-  if (length(unique(df$color))>1 && isTRUE(legend)) { p <- p + labs(color=color_name) } else { p <- p + guides(color="none") + scale_color_manual(values="black") }
+
+  colorscale <- NULL
+  if (length(unique(df$color))>1 && isTRUE(legend)) {
+    p <- p + labs(color=color_name)
+  } else {
+    p <- p + guides(color="none")
+    colorscale <- scale_color_manual(values="black")
+  }
   if (length(unique(df$color))>1 && isFALSE(legend)) { p <- p + guides(color="none") }
-  if (is.numeric(df$color)) p <- p + scale_color_gradientn(colors=colorRampPalette(rev(brewer.pal(n=5, name="RdYlBu")))(10)) 
+  if (is.numeric(df$color)) colorscale <- scale_color_gradientn(colors=colorRampPalette(rev(brewer.pal(n=5, name="RdYlBu")))(10))
   if (length(unique(df$shape))>1) { p <- p + labs(shape=shape_name) } else { p <- p + guides(shape = "none") }
+  if (!is.null(colorscale)) p <- p + colorscale
   if ((length(unique(df$color))>1 || length(unique(df$shape))>1) && isTRUE(legend)) { legend <- GGally::grab_legend(p) } else { legend <- NULL }
   
   # Generate plot
-  p <- GGally::ggpairs(df, 
+  p <- GGally::ggpairs(df,
     columns = factors,
-    lower = list(continuous=GGally::wrap("points", size=dot_size)), 
-    diag = list(continuous='densityDiag'), 
-    upper = list(continuous=GGally::wrap("points", size=dot_size)), 
-    mapping = aes_string(color="color_by", shape="shape_by"), 
-    title = "", 
+    lower = list(continuous=GGally::wrap("points", size=dot_size)),
+    diag = list(continuous='densityDiag'),
+    upper = list(continuous=GGally::wrap("points", size=dot_size)),
+    mapping = aes_string(color="color_by", shape="shape_by"),
+    title = "",
     legend = legend
     )
   p <- p + theme_bw() + theme(
@@ -442,7 +450,8 @@ plot_factors <- function(object, factors = c(1, 2), groups = "all",
     axis.ticks = element_blank(),
     axis.text = element_blank()
   )
-  
+  if (!is.null(colorscale)) p <- p + colorscale
+
   return(p)
 }
   


### PR DESCRIPTION
Currently, when plotting a pairs plot of factors, which happens automatically when `plot_factors` receives more than 2 factors, a red-blue color scale is applied to the legend, but not to the plot, which results in the plot and the legend having different color scales. This patch fixes this.

Current behavior:
![original](https://user-images.githubusercontent.com/3499574/191772264-6c415837-1efa-4551-85e8-21a4bb2e982d.png)

Patched:
![patched](https://user-images.githubusercontent.com/3499574/191772320-a7a282d8-a5af-4519-8ce8-2d13df9aff39.png)

