### PR TITLE
Fix to .set_colorby

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -390,7 +390,7 @@ setReplaceMethod("colnames", signature(x = "matrix_placeholder"),
     color_by <- samples_metadata(object)$group
     
     # Option 2: by a metadata column in object@samples$metadata
-  } else if ((length(color_by) == 1) && (is.character(color_by)|is.factor(color_by)) & (color_by[1] %in% colnames(samples_metadata(object)))) {
+  } else if ((length(color_by) == 1) && (is.character(color_by)|is.factor(color_by)) && (color_by[1] %in% colnames(samples_metadata(object)))) {
     color_by <- samples_metadata(object)[,color_by]
     # if (is.character(color_by)) color_by <- as.factor( color_by )
     


### PR DESCRIPTION
The single `&` at line [393 of 'utils.R'](https://github.com/bioFAM/MOFA2/blob/e605bf285bfa3ed98b3ebfb3b2e9d2b7a68c2717/R/utils.R#L393) was preventing the use of a character vector since it wouldn't stop even if the length was greater than 1.